### PR TITLE
Refactoring read partitions

### DIFF
--- a/fct_son.py
+++ b/fct_son.py
@@ -14,7 +14,8 @@ def sound(freq, duration):
     # g e n e r a t e s i n e wave tone
     tone = np.sin(freq * t * 2 * np.pi)
     # n o rm al i ze t o 24− b i t range
-    tone *= 8388607 / np.max(np.abs(tone))
+    if freq != 0:
+        tone *= 8388607 / np.max(np.abs(tone))
     # c o n v e r t t o 32− b i t da ta
     tone = tone.astype(np.int32)
     # c o n v e r t from 32− b i t t o 24− b i t by b u i l d i n g a new b y t e b u f f e r ,

--- a/lecture_partition.py
+++ b/lecture_partition.py
@@ -1,20 +1,10 @@
 # Projet Son: Paul Jouvanceau, Saul Delmotte, Jean Doutriaux
-# Le fichier comporte plusieurs fonctions utilisé dans l'interface graphique
+# Le fichier comporte plusieurs fonctions utilisées dans l'interface graphique
 
 from fct_son import *
 
-notes = {'DO': 264, 'RE': 297, 'MI': 330, 'FA': 352, 'SOL': 396, 'LA': 440, 'SI': 495, 'Z': 0}
+frequencies = {'DO': 264, 'RE': 297, 'MI': 330, 'FA': 352, 'SOL': 396, 'LA': 440, 'SI': 495, 'Z': 0}
 durations = {'c': 0.125, 'n': 0.25, 'b': 0.5, 'r': 1}
-p = "extend the duration of the previous note by 50 percent"
-
-
-# cette fonction sert a verifier si un element est dans un dictionnaire
-def in_dic(string, dic):
-    for k in dic:
-        if k == string:
-            return True
-    return False
-
 
 # Cette fonction sert à lire la partition et la jouer
 def play(song):
@@ -23,28 +13,19 @@ def play(song):
     user_partition = open("user_partition.txt")
     content.append(user_partition.readline())
     song -= 1
-    # On utilise un reader qui va lire lettre par lettre et se reinitialiser à chaque arguements trouvé
-    reader = ""
-    frequency = 0
-    duration = 0
-    for i in range(0, len(content[song])):
-        j = i + 2
-        reader += content[song][i]
-        if in_dic(reader, notes):
-            frequency = notes[reader]
-            reader = ""
-        elif in_dic(reader, durations):
-            duration = durations[reader]
-            reader = ""
-            if len(content[song]) > j and content[song][j] == "p":
-                duration *= 1.5
-        elif reader == " " or reader == "p":
-            reader = ""
-        # Quand chaque argument à été trouvé on peut appeler la fonction qui joue le son et reinitialiser ces variables
-        if frequency != 0 and duration != 0:
-            sound(frequency, duration)
-            frequency = 0
-            duration = 0
+    song_notes = content[song].split()
+    for i in range(len(song_notes)):
+        if song_notes[i] == 'p':
+            continue
+        note = song_notes[i][:-1]
+        dtag = song_notes[i][-1]
+        frequency = frequencies[note]
+        duration = durations[dtag]
+        j = i + 1
+        if j < len(song_notes) and song_notes[j] == "p":
+            duration *= 1.5
+        # to debug: print(song_notes[j], frequency, duration)
+        sound(frequency, duration)
     partition.close()
 
 


### PR DESCRIPTION
use split to read note by note the partition instead of char by char.
fix when frequency is 0 (was not played before, as tested freq + duration != 0)

todo: add check correct notes/tags to avoid error when invalid note/tag given
```python
if note not in frequencies:
  print('Warning: invalid note, skipping %s.', song_notes[i])
  continue
if dtag not in durations:
  print('Warning: invalid note, skipping %s.', song_notes[i])
  continue
```